### PR TITLE
Optics collector improvements

### DIFF
--- a/optics/optics.go
+++ b/optics/optics.go
@@ -1,6 +1,32 @@
 package optics
 
 type Optics struct {
-	RxPower float64
-	TxPower float64
+	Name  string
+	Index string
+
+	Temp    float64
+	TempHAT float64
+	TempHWT float64
+	TempLWT float64
+	TempLAT float64
+
+	Voltage    float64
+	VoltageHAT float64
+	VoltageHWT float64
+	VoltageLWT float64
+	VoltageLAT float64
+
+	TxPower    float64
+	TxPowerHAT float64
+	TxPowerHWT float64
+	TxPowerLWT float64
+	TxPowerLAT float64
+
+	RxPower    float64
+	RxPowerHAT float64
+	RxPowerHWT float64
+	RxPowerLWT float64
+	RxPowerLAT float64
+
+	Lanes map[string]*Optics
 }

--- a/optics/optics_collector.go
+++ b/optics/optics_collector.go
@@ -47,7 +47,7 @@ func (c *opticsCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metri
 
 	switch client.OSType {
 	case rpc.IOS, rpc.IOSXE:
-		iflistcmd = "show interfaces stats | exclude disabled"
+		iflistcmd = "show interfaces stats"
 	case rpc.NXOS:
 		iflistcmd = "show interface status | exclude disabled | exclude notconn | exclude sfpAbsent | exclude --------------------------------------------------------------------------------"
 	}

--- a/optics/optics_collector.go
+++ b/optics/optics_collector.go
@@ -12,14 +12,57 @@ import (
 const prefix string = "cisco_optics_"
 
 var (
-	opticsTXDesc *prometheus.Desc
-	opticsRXDesc *prometheus.Desc
+	opticsTempDesc    *prometheus.Desc
+	opticsTempHATDesc *prometheus.Desc
+	opticsTempHWTDesc *prometheus.Desc
+	opticsTempLATDesc *prometheus.Desc
+	opticsTempLWTDesc *prometheus.Desc
+
+	opticsVoltageDesc    *prometheus.Desc
+	opticsVoltageHATDesc *prometheus.Desc
+	opticsVoltageHWTDesc *prometheus.Desc
+	opticsVoltageLATDesc *prometheus.Desc
+	opticsVoltageLWTDesc *prometheus.Desc
+
+	opticsTXDesc    *prometheus.Desc
+	opticsTXHATDesc *prometheus.Desc
+	opticsTXHWTDesc *prometheus.Desc
+	opticsTXLATDesc *prometheus.Desc
+	opticsTXLWTDesc *prometheus.Desc
+
+	opticsRXDesc    *prometheus.Desc
+	opticsRXHATDesc *prometheus.Desc
+	opticsRXHWTDesc *prometheus.Desc
+	opticsRXLATDesc *prometheus.Desc
+	opticsRXLWTDesc *prometheus.Desc
 )
 
 func init() {
 	l := []string{"target", "interface"}
+	opticsTempDesc = prometheus.NewDesc(prefix+"temp", "Transceiver temperature in degrees Celsius", l, nil)
+	opticsTempHATDesc = prometheus.NewDesc(prefix+"temp_high_alarm_threshold", "Transceiver temperature high alarm threshold", l, nil)
+	opticsTempHWTDesc = prometheus.NewDesc(prefix+"temp_high_warn_threshold", "Transceiver temperature high warning threshold", l, nil)
+	opticsTempLATDesc = prometheus.NewDesc(prefix+"temp_low_alarm_threshold", "Transceiver temperature low alarm threshold", l, nil)
+	opticsTempLWTDesc = prometheus.NewDesc(prefix+"temp_low_warn_threshold", "Transceiver temperature low warning threshold", l, nil)
+
+	opticsVoltageDesc = prometheus.NewDesc(prefix+"module_voltage", "Transceiver voltage", l, nil)
+	opticsVoltageHATDesc = prometheus.NewDesc(prefix+"module_voltage_high_alarm_threshold", "Transceiver voltage high alarm threshold", l, nil)
+	opticsVoltageHWTDesc = prometheus.NewDesc(prefix+"module_voltage_high_warn_threshold", "Transceiver voltage high warning threshold", l, nil)
+	opticsVoltageLATDesc = prometheus.NewDesc(prefix+"module_voltage_low_alarm_threshold", "Transceiver voltage low alarm threshold", l, nil)
+	opticsVoltageLWTDesc = prometheus.NewDesc(prefix+"module_voltage_low_warn_threshold", "Transceiver voltage low warning threshold", l, nil)
+
+	l = append(l, "lane")
 	opticsTXDesc = prometheus.NewDesc(prefix+"tx", "Transceiver Tx power", l, nil)
+	opticsTXHATDesc = prometheus.NewDesc(prefix+"tx_high_alarm_threshold", "Transceiver tx power high alarm threshold", l, nil)
+	opticsTXHWTDesc = prometheus.NewDesc(prefix+"tx_high_warn_threshold", "Transceiver tx power high warning threshold", l, nil)
+	opticsTXLATDesc = prometheus.NewDesc(prefix+"tx_low_alarm_threshold", "Transceiver tx power low alarm threshold", l, nil)
+	opticsTXLWTDesc = prometheus.NewDesc(prefix+"tx_low_warn_threshold", "Transceiver tx power low warning threshold", l, nil)
+
 	opticsRXDesc = prometheus.NewDesc(prefix+"rx", "Transceiver Rx power", l, nil)
+	opticsRXHATDesc = prometheus.NewDesc(prefix+"rx_high_alarm_threshold", "Transceiver rx power high alarm threshold", l, nil)
+	opticsRXHWTDesc = prometheus.NewDesc(prefix+"rx_high_warn_threshold", "Transceiver rx power high warning threshold", l, nil)
+	opticsRXLATDesc = prometheus.NewDesc(prefix+"rx_low_alarm_threshold", "Transceiver rx power low alarm threshold", l, nil)
+	opticsRXLWTDesc = prometheus.NewDesc(prefix+"rx_low_warn_threshold", "Transceiver rx power low warning threshold", l, nil)
 }
 
 type opticsCollector struct {
@@ -37,8 +80,29 @@ func (*opticsCollector) Name() string {
 
 // Describe describes the metrics
 func (*opticsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- opticsTempDesc
+	ch <- opticsTempHATDesc
+	ch <- opticsTempHWTDesc
+	ch <- opticsTempLATDesc
+	ch <- opticsTempLWTDesc
+
+	ch <- opticsVoltageDesc
+	ch <- opticsVoltageHATDesc
+	ch <- opticsVoltageHWTDesc
+	ch <- opticsVoltageLATDesc
+	ch <- opticsVoltageLWTDesc
+
 	ch <- opticsTXDesc
+	ch <- opticsTXHATDesc
+	ch <- opticsTXHWTDesc
+	ch <- opticsTXLATDesc
+	ch <- opticsTXLWTDesc
+
 	ch <- opticsRXDesc
+	ch <- opticsRXHATDesc
+	ch <- opticsRXHWTDesc
+	ch <- opticsRXLATDesc
+	ch <- opticsRXLWTDesc
 }
 
 // Collect collects metrics from Cisco
@@ -62,10 +126,40 @@ func (c *opticsCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metri
 		}
 
 		for i, optics := range optics_data {
-			log.Printf("adding %s , %f", i, optics.RxPower)
 			l := append(labelValues, i)
-			ch <- prometheus.MustNewConstMetric(opticsTXDesc, prometheus.GaugeValue, float64(optics.TxPower), l...)
-			ch <- prometheus.MustNewConstMetric(opticsRXDesc, prometheus.GaugeValue, float64(optics.RxPower), l...)
+			ch <- prometheus.MustNewConstMetric(opticsTempDesc, prometheus.GaugeValue, float64(optics.Temp), l...)
+			ch <- prometheus.MustNewConstMetric(opticsTempHATDesc, prometheus.GaugeValue, float64(optics.TempHAT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsTempHWTDesc, prometheus.GaugeValue, float64(optics.TempHWT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsTempLATDesc, prometheus.GaugeValue, float64(optics.TempLAT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsTempLWTDesc, prometheus.GaugeValue, float64(optics.TempLWT), l...)
+
+			ch <- prometheus.MustNewConstMetric(opticsVoltageDesc, prometheus.GaugeValue, float64(optics.Voltage), l...)
+			ch <- prometheus.MustNewConstMetric(opticsVoltageHATDesc, prometheus.GaugeValue, float64(optics.VoltageHAT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsVoltageHWTDesc, prometheus.GaugeValue, float64(optics.VoltageHWT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsVoltageLATDesc, prometheus.GaugeValue, float64(optics.VoltageLAT), l...)
+			ch <- prometheus.MustNewConstMetric(opticsVoltageLWTDesc, prometheus.GaugeValue, float64(optics.VoltageLWT), l...)
+
+			var data map[string]*Optics
+			if len(optics.Lanes) > 0 {
+				data = optics.Lanes
+			} else {
+				data = map[string]*Optics{"": optics}
+			}
+
+			for _, e := range data {
+				l2 := append(l, e.Index)
+				ch <- prometheus.MustNewConstMetric(opticsTXDesc, prometheus.GaugeValue, float64(e.TxPower), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsTXHATDesc, prometheus.GaugeValue, float64(e.TxPowerHAT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsTXHWTDesc, prometheus.GaugeValue, float64(e.TxPowerHWT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsTXLATDesc, prometheus.GaugeValue, float64(e.TxPowerLAT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsTXLWTDesc, prometheus.GaugeValue, float64(e.TxPowerLWT), l2...)
+
+				ch <- prometheus.MustNewConstMetric(opticsRXDesc, prometheus.GaugeValue, float64(e.RxPower), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsRXHATDesc, prometheus.GaugeValue, float64(e.RxPowerHAT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsRXHWTDesc, prometheus.GaugeValue, float64(e.RxPowerHWT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsRXLATDesc, prometheus.GaugeValue, float64(e.RxPowerLAT), l2...)
+				ch <- prometheus.MustNewConstMetric(opticsRXLWTDesc, prometheus.GaugeValue, float64(e.RxPowerLWT), l2...)
+			}
 		}
 
 	case rpc.NXOS:

--- a/optics/optics_collector.go
+++ b/optics/optics_collector.go
@@ -80,7 +80,7 @@ func (c *opticsCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metri
 		optic, err := c.ParseTransceiver(client.OSType, out)
 		if err != nil {
 			if client.Debug {
-				log.Printf("Transceiver data for %s: %s\n", labelValues[0], err.Error())
+				log.Printf("Transceiver data for %s %s: %s\n", labelValues[0], i, err.Error())
 			}
 			continue
 		}

--- a/optics/parser.go
+++ b/optics/parser.go
@@ -84,11 +84,11 @@ func (c *opticsCollector) ParseTransceiver(ostype string, output string) (Optics
 }
 
 func (c *opticsCollector) ParseTransceiverAll(ostype string, output string) (map[string]*Optics, error) {
+	var data = map[string]*Optics{}
 	if ostype != rpc.IOS && ostype != rpc.IOSXE {
-		return map[string]*Optics{}, errors.New("All interface transceiver data is not implemented for " + ostype)
+		return data, errors.New("All interface transceiver data is not implemented for " + ostype)
 	}
 
-	var data = map[string]*Optics{}
 	re_section := regexp.MustCompile(`^\s+(Temperature|Voltage|Current|Transmit Power|Receive Power)`)
 	re_line := regexp.MustCompile(`^(?P<short_name>\w+\d+\S+)(?:\s+(?P<lane>(?:\d|N\/A)))?\s+(?P<value>(?:-?\d+\.\d+|N\/A))\s+(?P<high_alarm>(?:-?\d+\.\d+|N\/A))\s+(?P<high_warn>(?:-?\d+\.\d+|N\/A))\s+(?P<low_warn>(?:-?\d+\.\d+|N\/A))\s+(?P<low_alarm>(?:-?\d+\.\d+|N\/A))`)
 	var cur_section string
@@ -98,26 +98,79 @@ func (c *opticsCollector) ParseTransceiverAll(ostype string, output string) (map
 			cur_section = match[1]
 			continue
 		}
-		match = re_line.FindStringSubmatch(line)
-		if match != nil {
-			iface_name, err := util.InterfaceShortToLong(match[1])
+		matches := util.FindNamedMatches(re_line, line)
+		if len(matches) > 0 {
+			iface_name, err := util.InterfaceShortToLong(matches["short_name"])
 			if err != nil {
-				return map[string]*Optics{}, err
+				return data, err
 			}
 			optics, ok := data[iface_name]
 			if !ok {
-				optics = &Optics{}
+				optics = &Optics{
+					Index: "",
+					Name:  iface_name,
+					Lanes: make(map[string]*Optics),
+				}
 				data[iface_name] = optics
 			}
-			for group_idx, group_name := range re_line.SubexpNames() {
-				if group_idx != 0 && group_name != "" {
-					if group_name == "value" && cur_section == "Transmit Power" {
-						optics.TxPower = util.Str2float64Nan(match[group_idx])
+			if cur_section == "Temperature" {
+				optics.Temp = util.Str2float64Nan(matches["value"])
+				optics.TempHAT = util.Str2float64Nan(matches["high_alarm"])
+				optics.TempHWT = util.Str2float64Nan(matches["high_warn"])
+				optics.TempLAT = util.Str2float64Nan(matches["low_alarm"])
+				optics.TempLWT = util.Str2float64Nan(matches["low_warn"])
+			}
+
+			if cur_section == "Voltage" {
+				optics.Voltage = util.Str2float64Nan(matches["value"])
+				optics.VoltageHAT = util.Str2float64Nan(matches["high_alarm"])
+				optics.VoltageHWT = util.Str2float64Nan(matches["high_warn"])
+				optics.VoltageLAT = util.Str2float64Nan(matches["low_alarm"])
+				optics.VoltageLWT = util.Str2float64Nan(matches["low_warn"])
+			}
+
+			if cur_section == "Transmit Power" {
+				lane_name, ok := matches["lane"]
+				var lane *Optics
+				if ok && lane_name != "N/A" {
+					lane, ok = optics.Lanes[lane_name]
+					if !ok {
+						lane = &Optics{
+							Name:  iface_name,
+							Index: lane_name,
+						}
+						optics.Lanes[lane_name] = lane
 					}
-					if group_name == "value" && cur_section == "Receive Power" {
-						optics.RxPower = util.Str2float64Nan(match[group_idx])
-					}
+				} else {
+					lane = optics
 				}
+				lane.TxPower = util.Str2float64Nan(matches["value"])
+				lane.TxPowerHAT = util.Str2float64Nan(matches["high_alarm"])
+				lane.TxPowerHWT = util.Str2float64Nan(matches["high_warn"])
+				lane.TxPowerLAT = util.Str2float64Nan(matches["low_alarm"])
+				lane.TxPowerLWT = util.Str2float64Nan(matches["low_warn"])
+			}
+
+			if cur_section == "Receive Power" {
+				lane_name, ok := matches["lane"]
+				var lane *Optics
+				if ok && lane_name != "N/A" {
+					lane, ok = optics.Lanes[lane_name]
+					if !ok {
+						lane = &Optics{
+							Name:  iface_name,
+							Index: lane_name,
+						}
+						optics.Lanes[lane_name] = lane
+					}
+				} else {
+					lane = optics
+				}
+				lane.RxPower = util.Str2float64Nan(matches["value"])
+				lane.RxPowerHAT = util.Str2float64Nan(matches["high_alarm"])
+				lane.RxPowerHWT = util.Str2float64Nan(matches["high_warn"])
+				lane.RxPowerLAT = util.Str2float64Nan(matches["low_alarm"])
+				lane.RxPowerLWT = util.Str2float64Nan(matches["low_warn"])
 			}
 		}
 	}

--- a/optics/parser.go
+++ b/optics/parser.go
@@ -15,12 +15,20 @@ func (c *opticsCollector) ParseInterfaces(ostype string, output string) ([]strin
 		return nil, errors.New("'show interfaces stats' is not implemented for " + ostype)
 	}
 	var items []string
-	deviceNameRegexp, _ := regexp.Compile(`^([a-zA-Z0-9\/\.-]+)\s*`)
+	virtualNames := [4]string{"Vlan", "Loopback", "Tunnel", "Port-channel"}
+	deviceNameRegexp, _ := regexp.Compile(`^(?:Interface\s)?([a-zA-Z0-9\/\.-]+)(?: is disabled)?\s*$`)
 	lines := strings.Split(output, "\n")
+LINES:
 	for _, line := range lines {
 		matches := deviceNameRegexp.FindStringSubmatch(line)
 		if matches == nil {
 			continue
+		}
+		// ignore virtual interfaces
+		for _, virtualName := range virtualNames {
+			if strings.HasPrefix(matches[1], virtualName) {
+				continue LINES
+			}
 		}
 		items = append(items, matches[1])
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,11 @@
 package util
 
-import "strconv"
+import (
+	"errors"
+	"math"
+	"regexp"
+	"strconv"
+)
 
 // Str2float64 converts a string to float64
 func Str2float64(str string) float64 {
@@ -9,4 +14,58 @@ func Str2float64(str string) float64 {
 		return -1
 	}
 	return value
+}
+
+// convert string to float64, but return N/A as NaN
+func Str2float64Nan(str string) float64 {
+	if str == "N/A" {
+		return math.NaN()
+	}
+	return Str2float64(str)
+}
+
+var InterfaceTypes = map[string]string{
+	"Fa":                      "FastEthernet",
+	"Gi":                      "GigabitEthernet",
+	"Te":                      "TenGigabitEthernet",
+	"Twe":                     "TwentyFiveGigE",
+	"Fo":                      "FortyGigabitEthernet",
+	"Hu":                      "HundredGigE",
+	"Et":                      "Ethernet",
+	"Eth":                     "Ethernet",
+	"Vl":                      "Vlan",
+	"FD":                      "Fddi",
+	"Po":                      "Port-channel",
+	"PortCh":                  "Port-channel",
+	"Tu":                      "Tunnel",
+	"Lo":                      "Loopback",
+	"Vi":                      "Virtual-Access",
+	"Vt":                      "Virtual-Template",
+	"EO":                      "EOBC",
+	"Di":                      "Dialer",
+	"Se":                      "Serial",
+	"PO":                      "POS",
+	"PosCh":                   "Pos-channel",
+	"Mu":                      "Multilink",
+	"AT":                      "ATM",
+	"Async":                   "Async",
+	"Group-Async":             "Group-Async",
+	"MFR":                     "MFR",
+	"BRI":                     "BRI",
+	"BVI":                     "BVI",
+	"Null":                    "Null",
+	"Embedded-Service-Engine": "Embedded-Service-Engine",
+}
+
+func InterfaceShortToLong(shortName string) (string, error) {
+	re, _ := regexp.Compile(`^([^\d+]+)(\d?.*)`)
+	match := re.FindStringSubmatch(shortName)
+	if match == nil {
+		return "", errors.New("Cannot extract short type from given name")
+	}
+	longName, ok := InterfaceTypes[match[1]]
+	if ok {
+		return longName + match[2], nil
+	}
+	return "", errors.New("No long form found for name")
 }

--- a/util/util.go
+++ b/util/util.go
@@ -69,3 +69,15 @@ func InterfaceShortToLong(shortName string) (string, error) {
 	}
 	return "", errors.New("No long form found for name")
 }
+
+// https://stackoverflow.com/a/46202939
+// return regexp named capture groups as map
+func FindNamedMatches(r *regexp.Regexp, str string) map[string]string {
+	match := r.FindStringSubmatch(str)
+	subMatchMap := make(map[string]string)
+	for i, value := range match {
+		subMatchMap[r.SubexpNames()[i]] = value
+	}
+
+	return subMatchMap
+}


### PR DESCRIPTION
parsing of optics for IOS-XE was broken and returned bogus values for RX signal. This was fixes.

Also added metrics for voltage, temperature and thresholds:

```
# HELP cisco_optics_module_voltage Transceiver voltage
# TYPE cisco_optics_module_voltage gauge
cisco_optics_module_voltage{interface="TenGigabitEthernet1/12",target="example.host"} 3.35
# HELP cisco_optics_module_voltage_high_alarm_threshold Transceiver voltage high alarm threshold
# TYPE cisco_optics_module_voltage_high_alarm_threshold gauge
cisco_optics_module_voltage_high_alarm_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 3.63
# HELP cisco_optics_module_voltage_high_warn_threshold Transceiver voltage high warning threshold
# TYPE cisco_optics_module_voltage_high_warn_threshold gauge
cisco_optics_module_voltage_high_warn_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 3.47
# HELP cisco_optics_module_voltage_low_alarm_threshold Transceiver voltage low alarm threshold
# TYPE cisco_optics_module_voltage_low_alarm_threshold gauge
cisco_optics_module_voltage_low_alarm_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 2.97
# HELP cisco_optics_module_voltage_low_warn_threshold Transceiver voltage low warning threshold
# TYPE cisco_optics_module_voltage_low_warn_threshold gauge
cisco_optics_module_voltage_low_warn_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 3.14
# HELP cisco_optics_rx Transceiver Rx power
# TYPE cisco_optics_rx gauge
cisco_optics_rx{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -40
# HELP cisco_optics_rx_high_alarm_threshold Transceiver rx power high alarm threshold
# TYPE cisco_optics_rx_high_alarm_threshold gauge
cisco_optics_rx_high_alarm_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} 0.9
# HELP cisco_optics_rx_high_warn_threshold Transceiver rx power high warning threshold
# TYPE cisco_optics_rx_high_warn_threshold gauge
cisco_optics_rx_high_warn_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -3
# HELP cisco_optics_rx_low_alarm_threshold Transceiver rx power low alarm threshold
# TYPE cisco_optics_rx_low_alarm_threshold gauge
cisco_optics_rx_low_alarm_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -23
# HELP cisco_optics_rx_low_warn_threshold Transceiver rx power low warning threshold
# TYPE cisco_optics_rx_low_warn_threshold gauge
cisco_optics_rx_low_warn_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -19
# HELP cisco_optics_temp Transceiver temperature in degrees Celsius
# TYPE cisco_optics_temp gauge
cisco_optics_temp{interface="TenGigabitEthernet1/12",target="example.host"} 26.6
# HELP cisco_optics_temp_high_alarm_threshold Transceiver temperature high alarm threshold
# TYPE cisco_optics_temp_high_alarm_threshold gauge
cisco_optics_temp_high_alarm_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 90
# HELP cisco_optics_temp_high_warn_threshold Transceiver temperature high warning threshold
# TYPE cisco_optics_temp_high_warn_threshold gauge
cisco_optics_temp_high_warn_threshold{interface="TenGigabitEthernet1/12",target="example.host"} 85
# HELP cisco_optics_temp_low_alarm_threshold Transceiver temperature low alarm threshold
# TYPE cisco_optics_temp_low_alarm_threshold gauge
cisco_optics_temp_low_alarm_threshold{interface="TenGigabitEthernet1/12",target="example.host"} -10
# HELP cisco_optics_temp_low_warn_threshold Transceiver temperature low warning threshold
# TYPE cisco_optics_temp_low_warn_threshold gauge
cisco_optics_temp_low_warn_threshold{interface="TenGigabitEthernet1/12",target="example.host"} -5
# HELP cisco_optics_tx Transceiver Tx power
# TYPE cisco_optics_tx gauge
cisco_optics_tx{interface="TenGigabitEthernet1/12",lane="",target="example.host"} NaN
# HELP cisco_optics_tx_high_alarm_threshold Transceiver tx power high alarm threshold
# TYPE cisco_optics_tx_high_alarm_threshold gauge
cisco_optics_tx_high_alarm_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} 0.9
# HELP cisco_optics_tx_high_warn_threshold Transceiver tx power high warning threshold
# TYPE cisco_optics_tx_high_warn_threshold gauge
cisco_optics_tx_high_warn_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -3
# HELP cisco_optics_tx_low_alarm_threshold Transceiver tx power low alarm threshold
# TYPE cisco_optics_tx_low_alarm_threshold gauge
cisco_optics_tx_low_alarm_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -13.5
# HELP cisco_optics_tx_low_warn_threshold Transceiver tx power low warning threshold
# TYPE cisco_optics_tx_low_warn_threshold gauge
cisco_optics_tx_low_warn_threshold{interface="TenGigabitEthernet1/12",lane="",target="example.host"} -9.5
```

This also supports multi-lane optics.
