### PR TITLE
speedup neighbors collector

### DIFF
--- a/neighbors/neighbors.go
+++ b/neighbors/neighbors.go
@@ -1,9 +1,9 @@
 package neighbors
 
 type InterfaceNeighors struct {
-	Incomplete float64
-	Reachable  float64
-	Stale      float64
-	Delay      float64
-	Probe      float64
+	Incomplete float64 `default:"0"`
+	Reachable  float64 `default:"0"`
+	Stale      float64 `default:"0"`
+	Delay      float64 `default:"0"`
+	Probe      float64 `default:"0"`
 }


### PR DESCRIPTION
For IOS & IOS XE parse a different commend that returns all neighbors in one command instead of running one for each interface. This results in ~10x speedup