### PR TITLE
add temperature state to environment collector

### DIFF
--- a/environment/parser.go
+++ b/environment/parser.go
@@ -10,6 +10,34 @@ import (
 )
 
 // Parse parses cli output and tries to find oll temperature and power related data
+/*
+# almost every Cisco model has different output
+# ISOXE C9500 example
+#sh environment all
+Sensor List:  Environmental Monitoring
+ Sensor                  Location        State           Reading
+ PSOC-MB_0: VOUT         R0              Normal          12079 mV
+ 35215MB2_0: VOU         R0              Normal          898 mV
+ Temp: Outlet_A          R0              Normal          28 Celsius
+ Temp: UADP_0_8          R0              Normal          38 Celsius
+ PSOC-DB_1: VOUT         R0              Normal          4999 mV
+ 3570DB3_0: VOUT         R0              Normal          1048 mV
+ Temp: Coretemp          R0              Normal          30 Celsius
+ Temp: OutletDB          R0              Normal          25 Celsius
+
+Power                                                    Fan States
+Supply  Model No              Type  Capacity  Status     0     1
+------  --------------------  ----  --------  ---------  -----------
+PS0     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
+PS1     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
+
+Fan                 Fan States
+Tray    Status      0     1     2     3
+------  ----------  -----------------------
+FM0     ok          good  good  good  good
+FM1     ok          good  good  good  good
+
+*/
 func (c *environmentCollector) Parse(ostype string, output string) ([]EnvironmentItem, error) {
 	if ostype != rpc.IOSXE && ostype != rpc.NXOS && ostype != rpc.IOS {
 		return nil, errors.New("'show environment' is not implemented for " + ostype)
@@ -17,20 +45,24 @@ func (c *environmentCollector) Parse(ostype string, output string) ([]Environmen
 	items := []EnvironmentItem{}
 	tempRegexp := make(map[string]*regexp.Regexp)
 	powerRegexp := make(map[string]*regexp.Regexp)
-	tempRegexp[rpc.IOSXE], _ = regexp.Compile(`\s*Temp: (\w+)\s+(\w+)\s+\w+\s+(\d+) Celsius`)
+	tempRegexp[rpc.IOSXE], _ = regexp.Compile(`\s*Temp: (?P<sensor>\w+)\s+(?P<location>\w+)\s+(?P<state>\w+)\s+(?P<value>\d+) Celsius`)
 	powerRegexp[rpc.IOSXE], _ = regexp.Compile(`(PS\d+)\s+([\w\-]+)\s+\w+\s+\d+\s\w+\s+(\w+)`)
-	tempRegexp[rpc.IOS], _ = regexp.Compile(`^(\d+)\s+(air \w+(?: +\w+)?)\s+(\d+)C \(.*\)\s+\w+$`)
+	tempRegexp[rpc.IOS], _ = regexp.Compile(`^(?P<location>\d+)\s+(?P<sensor>air \w+(?: +\w+)?)\s+(?P<value>\d+)C \(.*\)\s+\w+$`)
 	powerRegexp[rpc.IOS], _ = regexp.Compile(`^(\w+)\s+.+\s+(AC) \w+\s+(\w+)\s+\w+\s+.+\s+.+$`)
-	tempRegexp[rpc.NXOS], _ = regexp.Compile(`^(\d+)\s+(.+)\s+\d\d?\s+\d\d?\s+(\d\d?)\s+\w+\s*$`)
+	tempRegexp[rpc.NXOS], _ = regexp.Compile(`^(?P<location>\d+)\s+(?P<sensor>.+)\s+\d\d?\s+\d\d?\s+(?P<value>\d\d?)\s+\w+\s*$`)
 	powerRegexp[rpc.NXOS], _ = regexp.Compile(`^(\d+)\s+.+\s+(AC)\s+.+\s+.+\s+(\w+)\s*$`)
 
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
-		if matches := tempRegexp[ostype].FindStringSubmatch(line); matches != nil {
+		if matches := util.FindNamedMatches(tempRegexp[ostype], line); len(matches) > 0 {
 			x := EnvironmentItem{
-				Name:        strings.TrimSpace(matches[1] + " " + matches[2]),
+				Name:        strings.TrimSpace(matches["location"] + " " + matches["sensor"]),
 				IsTemp:      true,
-				Temperature: util.Str2float64(matches[3]),
+				Temperature: util.Str2float64(matches["value"]),
+			}
+			if state, ok := matches["state"]; ok {
+				x.OK = state == "Normal" || state == "good" || state == "ok" || state == "GREEN"
+				x.Status = state
 			}
 			items = append(items, x)
 		} else if matches := powerRegexp[ostype].FindStringSubmatch(line); matches != nil {


### PR DESCRIPTION
in environment collector for temp parse state into metric

```
# HELP cisco_environment_sensor_status Status of sensor temperatures (1 OK, 0 Something is wrong)
# TYPE cisco_environment_sensor_status gauge
cisco_environment_sensor_status{item="R0 Coretemp",status="Normal"} 1
```

This will work on Cisco IOSXE C9500 series. Probably not on other model series, because almost every series has completely different output.
 