### PR TITLE
add environment fan status metrics

### DIFF
--- a/environment/environment_collector.go
+++ b/environment/environment_collector.go
@@ -21,7 +21,7 @@ func init() {
 	l := []string{"target", "item"}
 	temperaturesDesc = prometheus.NewDesc(prefix+"sensor_temp", "Sensor temperatures", l, nil)
 	l = append(l, "status")
-	temperaturesStatusDesc = prometheus.NewDesc(prefix+"sensor_status", "Status of sensor temperatures (1 OK, 0 Something is wrong)", l, nil)
+	temperaturesStatusDesc = prometheus.NewDesc(prefix+"sensor_temp_status", "Status of sensor temperatures (1 OK, 0 Something is wrong)", l, nil)
 	powerSupplyDesc = prometheus.NewDesc(prefix+"power_up", "Status of power supplies (1 OK, 0 Something is wrong)", l, nil)
 }
 

--- a/environment/environment_collector.go
+++ b/environment/environment_collector.go
@@ -15,6 +15,7 @@ var (
 	temperaturesDesc       *prometheus.Desc
 	temperaturesStatusDesc *prometheus.Desc
 	powerSupplyDesc        *prometheus.Desc
+	fanStatusDesc          *prometheus.Desc
 )
 
 func init() {
@@ -23,6 +24,7 @@ func init() {
 	l = append(l, "status")
 	temperaturesStatusDesc = prometheus.NewDesc(prefix+"sensor_temp_status", "Status of sensor temperatures (1 OK, 0 Something is wrong)", l, nil)
 	powerSupplyDesc = prometheus.NewDesc(prefix+"power_up", "Status of power supplies (1 OK, 0 Something is wrong)", l, nil)
+	fanStatusDesc = prometheus.NewDesc(prefix+"fan_status", "Status of fan (1 OK, 0 Something is wrong)", l, nil)
 }
 
 type environmentCollector struct {
@@ -43,6 +45,7 @@ func (*environmentCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- temperaturesDesc
 	ch <- temperaturesStatusDesc
 	ch <- powerSupplyDesc
+	ch <- fanStatusDesc
 }
 
 // Collect collects metrics from Cisco
@@ -77,6 +80,13 @@ func (c *environmentCollector) Collect(client *rpc.Client, ch chan<- prometheus.
 			}
 			l = append(l, item.Status)
 			ch <- prometheus.MustNewConstMetric(temperaturesStatusDesc, prometheus.GaugeValue, float64(val), l...)
+		} else if item.IsFan {
+			val := 0
+			if item.OK {
+				val = 1
+			}
+			l = append(l, item.Status)
+			ch <- prometheus.MustNewConstMetric(fanStatusDesc, prometheus.GaugeValue, float64(val), l...)
 		} else {
 			val := 0
 			if item.OK {

--- a/environment/environment_item.go
+++ b/environment/environment_item.go
@@ -4,6 +4,7 @@ type EnvironmentItem struct {
 	Name        string
 	Status      string
 	OK          bool
-	IsTemp      bool
+	IsTemp      bool `default:"false"`
+	IsFan       bool `default:"false"`
 	Temperature float64
 }

--- a/environment/parser.go
+++ b/environment/parser.go
@@ -43,6 +43,44 @@ func (c *environmentCollector) Parse(ostype string, output string) ([]Environmen
 		return nil, errors.New("'show environment' is not implemented for " + ostype)
 	}
 	items := []EnvironmentItem{}
+
+	results_temp, err := util.ParseTextfsm(templ_temp, output)
+	if err != nil {
+		return items, errors.New("Error parsing via templ_temp: " + err.Error())
+	}
+	results_power, err := util.ParseTextfsm(templ_power, output)
+	if err != nil {
+		return items, errors.New("Error parsing via templ_power: " + err.Error())
+	}
+	for _, result := range results_temp {
+		location := result["LOCATION"].(string)
+		sensor := result["SENSOR"].(string)
+		state := strings.ToLower(strings.TrimSpace(result["STATE"].(string)))
+		state_ok := state == "normal" || state == "good" || state == "ok" || state == "green"
+		x := EnvironmentItem{
+			Name:        strings.TrimSpace(location + " " + sensor),
+			IsTemp:      true,
+			OK:          state_ok,
+			Status:      state,
+			Temperature: util.Str2float64(result["VALUE"].(string)),
+		}
+		items = append(items, x)
+	}
+	for _, result := range results_power {
+		location := result["LOCATION"].(string)
+		model := result["MODEL"].(string)
+		status := strings.ToLower(strings.TrimSpace(result["STATUS"].(string)))
+		status_ok := status == "normal" || status == "good" || status == "ok" || status == "green"
+		x := EnvironmentItem{
+			Name:   strings.TrimSpace(location + " " + model),
+			IsTemp: false,
+			OK:     status_ok,
+			Status: status,
+		}
+		items = append(items, x)
+	}
+	return items, nil
+
 	tempRegexp := make(map[string]*regexp.Regexp)
 	powerRegexp := make(map[string]*regexp.Regexp)
 	tempRegexp[rpc.IOSXE], _ = regexp.Compile(`^\s*(?:Temp: )?(?P<sensor>(?:\w+\s?)+)\s+(?P<location>\w+)\s+(?P<state>(?:\w+\s?)+)\s+(?P<value>\d+) Celsius`)

--- a/environment/parser.go
+++ b/environment/parser.go
@@ -2,44 +2,15 @@ package environment
 
 import (
 	"errors"
-	"regexp"
 	"strings"
 
 	"github.com/lwlcom/cisco_exporter/rpc"
 	"github.com/lwlcom/cisco_exporter/util"
 )
 
-// Parse parses cli output and tries to find oll temperature and power related data
-/*
-# almost every Cisco model has different output
-# ISOXE C9500 example
-#sh environment all
-Sensor List:  Environmental Monitoring
- Sensor                  Location        State           Reading
- PSOC-MB_0: VOUT         R0              Normal          12079 mV
- 35215MB2_0: VOU         R0              Normal          898 mV
- Temp: Outlet_A          R0              Normal          28 Celsius
- Temp: UADP_0_8          R0              Normal          38 Celsius
- PSOC-DB_1: VOUT         R0              Normal          4999 mV
- 3570DB3_0: VOUT         R0              Normal          1048 mV
- Temp: Coretemp          R0              Normal          30 Celsius
- Temp: OutletDB          R0              Normal          25 Celsius
-
-Power                                                    Fan States
-Supply  Model No              Type  Capacity  Status     0     1
-------  --------------------  ----  --------  ---------  -----------
-PS0     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
-PS1     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
-
-Fan                 Fan States
-Tray    Status      0     1     2     3
-------  ----------  -----------------------
-FM0     ok          good  good  good  good
-FM1     ok          good  good  good  good
-
-*/
+// Parse parses cli output using textfsm and tries to find all temperature, power & fan related data
 func (c *environmentCollector) Parse(ostype string, output string) ([]EnvironmentItem, error) {
-	if ostype != rpc.IOSXE && ostype != rpc.NXOS && ostype != rpc.IOS {
+	if ostype != rpc.IOSXE && ostype != rpc.IOS {
 		return nil, errors.New("'show environment' is not implemented for " + ostype)
 	}
 	items := []EnvironmentItem{}
@@ -78,42 +49,6 @@ func (c *environmentCollector) Parse(ostype string, output string) ([]Environmen
 			Status: status,
 		}
 		items = append(items, x)
-	}
-	return items, nil
-
-	tempRegexp := make(map[string]*regexp.Regexp)
-	powerRegexp := make(map[string]*regexp.Regexp)
-	tempRegexp[rpc.IOSXE], _ = regexp.Compile(`^\s*(?:Temp: )?(?P<sensor>(?:\w+\s?)+)\s+(?P<location>\w+)\s+(?P<state>(?:\w+\s?)+)\s+(?P<value>\d+) Celsius`)
-	powerRegexp[rpc.IOSXE], _ = regexp.Compile(`(PS\d+)\s+([\w\-]+)\s+\w+\s+\d+\s\w+\s+(\w+)`)
-	tempRegexp[rpc.IOS], _ = regexp.Compile(`^(?P<location>\d+)\s+(?P<sensor>air \w+(?: +\w+)?)\s+(?P<value>\d+)C \(.*\)\s+\w+$`)
-	powerRegexp[rpc.IOS], _ = regexp.Compile(`^(\w+)\s+.+\s+(AC) \w+\s+(\w+)\s+\w+\s+.+\s+.+$`)
-	tempRegexp[rpc.NXOS], _ = regexp.Compile(`^(?P<location>\d+)\s+(?P<sensor>.+)\s+\d\d?\s+\d\d?\s+(?P<value>\d\d?)\s+\w+\s*$`)
-	powerRegexp[rpc.NXOS], _ = regexp.Compile(`^(\d+)\s+.+\s+(AC)\s+.+\s+.+\s+(\w+)\s*$`)
-
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if matches := util.FindNamedMatches(tempRegexp[ostype], line); len(matches) > 0 {
-			x := EnvironmentItem{
-				Name:        strings.TrimSpace(matches["location"]) + " " + strings.TrimSpace(matches["sensor"]),
-				IsTemp:      true,
-				Temperature: util.Str2float64(matches["value"]),
-			}
-			if state, ok := matches["state"]; ok {
-				state = strings.ToLower(strings.TrimSpace(state))
-				x.OK = state == "normal" || state == "good" || state == "ok" || state == "green"
-				x.Status = state
-			}
-			items = append(items, x)
-		} else if matches := powerRegexp[ostype].FindStringSubmatch(line); matches != nil {
-			ok := matches[3] == "Normal" || matches[3] == "good" || matches[3] == "ok"
-			x := EnvironmentItem{
-				Name:   strings.TrimSpace(matches[1] + " " + matches[2]),
-				IsTemp: false,
-				OK:     ok,
-				Status: matches[3],
-			}
-			items = append(items, x)
-		}
 	}
 	return items, nil
 }

--- a/environment/templates.go
+++ b/environment/templates.go
@@ -14,7 +14,6 @@ package environment
  * 1A  PWR-C5-600WAC       123          OK              Good     Good     600
  * 1B  Not Present
  */
-
 var templ_power = `# show environment all
 Value LOCATION (\w+)
 Value MODEL ([\w\-]+)
@@ -63,4 +62,59 @@ Value VALUE (\d+)
 Start
   ^\s*(?:Temp: )?${SENSOR}\s+${LOCATION}\s+${STATE}\s+${VALUE} Celsius -> Record
   ^$ -> End
+`
+
+/*
+ * # C9500
+ * Power                                                    Fan States
+ * Supply  Model No              Type  Capacity  Status     0     1
+ * ------  --------------------  ----  --------  ---------  -----------
+ * PS0     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
+ * PS1     C9K-PWR-650WAC-R      AC    650 W     fail       N/A   N/A
+ *
+ * Fan                 Fan States
+ * Tray    Status      0     1     2     3
+ * ------  ----------  -----------------------
+ * FM0     ok          good  good  good  good
+ * FM1     ok          good  good  good  good
+ *
+ * # C9200L
+ * Sensor List: Environmental Monitoring
+ *  Sensor          Location        State               Reading       Range(min-max)
+ *  PS1 Hotspot     1               GOOD                  31 Celsius     na
+ *  PS1 Fan Status  1               GOOD               43008 rpm         na
+ *  PS2 Hotspot     1               NOT PRESENT            0 Celsius     na
+ *  PS2 Fan Status  1               NOT PRESENT            0 rpm         na
+ *
+ * Switch	 FAN	 Speed	 State	 Airflow direction
+ * ---------------------------------------------------
+ *   1  	  1    5100 	  OK	 Front to Back
+ *   1  	  2	   5145 	  OK	 Front to Back
+ *
+ */
+var templ_fan = `# show environment all
+Value Filldown NAME ((?:\w+\s?)+)
+Value LOCATION (\w+)
+Value STATUS ((?:\w+[\s\/]?)+)
+Value STATUS1 ((?:\w+[\s\/]?)+)
+Value VALUE (\d+)
+Value PWR_MODEL ([\w\-]+)
+
+Start
+  ^\s*${NAME}\s+${LOCATION}\s+${STATUS}\s+${VALUE} rpm -> Record
+  ^Tray\s+Status -> Fan_C9500
+  ^Supply\s+Model -> Fan_C9500_PWR
+  ^Switch\s+FAN -> Fan_C9200L
+
+Fan_C9500
+  ^${NAME}\s+${STATUS} -> Record
+  ^$ -> Start
+
+Fan_C9500_PWR
+  ^${LOCATION}\s+${PWR_MODEL}\s+\w+\s+\d+\s\w+\s+\w+\s+${STATUS}\s+${STATUS1} -> Record
+  ^$ -> Start
+
+Fan_C9200L
+  ^\s*${LOCATION}\s+${NAME}\s+${VALUE}\s+${STATUS} -> Record
+  ^$ -> Start
 `

--- a/environment/templates.go
+++ b/environment/templates.go
@@ -1,0 +1,66 @@
+package environment
+
+/*
+ * # C9500
+ * Power                                                    Fan States
+ * Supply  Model No              Type  Capacity  Status     0     1
+ * ------  --------------------  ----  --------  ---------  -----------
+ * PS0     C9K-PWR-650WAC-R      AC    650 W     ok         good  N/A
+ * PS1     C9K-PWR-650WAC-R      AC    650 W     fail       N/A   N/A
+ *
+ * # C9200L
+ * SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+ * --  ------------------  ----------  ---------------  -------  -------  -----
+ * 1A  PWR-C5-600WAC       123          OK              Good     Good     600
+ * 1B  Not Present
+ */
+
+var templ_power = `# show environment all
+Value LOCATION (\w+)
+Value MODEL ([\w\-]+)
+Value TYPE (\w+)
+Value CAPACITY (\d+\s\w+)
+Value STATUS ([nN]ot [pP]resent|\w+)
+
+Start
+  ^Supply\s+Model -> Power_C9500
+  ^SW\s+PID -> Power_C9200L
+
+Power_C9500
+  ^${LOCATION}\s+${MODEL}\s+${TYPE}\s+${CAPACITY}\s+${STATUS} -> Record
+  ^$ -> End
+  
+Power_C9200L
+  ^${LOCATION}\s+${MODEL}\s+\w+\s+${STATUS} -> Record
+  ^${LOCATION}\s+${STATUS} -> Record
+  ^$ -> End
+`
+
+/*
+ * # C9500
+ * Sensor List:  Environmental Monitoring
+ *  Sensor                  Location        State           Reading
+ *  PSOC-MB_0: VOUT         R0              Normal          12116 mV
+ *  Temp: Coretemp          R0              Normal          35 Celsius
+ *  Temp: OutletDB          R0              Normal          29 Celsius
+ *
+ * # C9200L
+ * Sensor List: Environmental Monitoring
+ *  Sensor          Location        State               Reading       Range(min-max)
+ *  PS1 Vout        1               GOOD               55000 mV          na
+ *  PS1 Hotspot     1               GOOD                  31 Celsius     na
+ *  PS1 Fan Status  1               GOOD               43008 rpm         na
+ *  PS1 Status word 1               GOOD                   2             na
+ *  PS2 Hotspot     1               NOT PRESENT            0 Celsius     na
+ *  SYSTEM INLET    1               GREEN                 23 Celsius   0 - 56
+ */
+var templ_temp = `# show environment all
+Value SENSOR ((?:\w+\s?)+)
+Value LOCATION (\w+)
+Value STATE ((?:\w+\s?)+)
+Value VALUE (\d+)
+
+Start
+  ^\s*(?:Temp: )?${SENSOR}\s+${LOCATION}\s+${STATE}\s+${VALUE} Celsius -> Record
+  ^$ -> End
+`

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1 // indirect
+	github.com/sirikothe/gotextfsm v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sirikothe/gotextfsm v1.0.0 h1:4kKwbUziG9G+31PfLY+vI3FzYK/kcByh4ndT3NyPMkc=
+github.com/sirikothe/gotextfsm v1.0.0/go.mod h1:CJYqpTg9u5VPCoD0VEl9E68prCIiWQD8m457k098DdQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/util/util.go
+++ b/util/util.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+
+	"github.com/sirikothe/gotextfsm"
 )
 
 // Str2float64 converts a string to float64
@@ -80,4 +82,18 @@ func FindNamedMatches(r *regexp.Regexp, str string) map[string]string {
 	}
 
 	return subMatchMap
+}
+
+func ParseTextfsm(template string, output string) ([]map[string]interface{}, error) {
+	fsm := gotextfsm.TextFSM{}
+	err := fsm.ParseString(template)
+	if err != nil {
+		return nil, errors.New("textfsm error while parsing template: " + err.Error())
+	}
+	parser := gotextfsm.ParserOutput{}
+	err = parser.ParseTextString(output, fsm, true)
+	if err != nil {
+		return nil, errors.New("textfsm error while parsing output: " + err.Error())
+	}
+	return parser.Dict, nil
 }


### PR DESCRIPTION
Example:

```
# HELP cisco_environment_fan_status Status of fan (1 OK, 0 Something is wrong)
# TYPE cisco_environment_fan_status gauge
cisco_environment_fan_status{item="FM0",status="ok",target="..."} 1
cisco_environment_fan_status{item="FM1",status="ok",target="..."} 1
cisco_environment_fan_status{item="PS0 0",status="good",target="..."} 1
cisco_environment_fan_status{item="PS0 1",status="n/a",target="..."} 0
cisco_environment_fan_status{item="PS1 0",status="n/a",target="..."} 0
cisco_environment_fan_status{item="PS1 1",status="n/a",target="..."} 0
```

Also introduces dependency on [textfsm](https://github.com/sirikothe/gotextfsm) and environment collector uses it to parse outputs.

