### PR TITLE
report interface operState as down if line protocol is down

### DIFF
--- a/interfaces/parser.go
+++ b/interfaces/parser.go
@@ -19,7 +19,7 @@ func (c *interfaceCollector) Parse(ostype string, output string) ([]Interface, e
 	newIfRegexp := regexp.MustCompile(`(?:^!?(?: |admin|show|.+#).*$|^$)`)
 	macRegexp := regexp.MustCompile(`^\s+Hardware(?: is|:) .+, address(?: is|:) (.*) \(.*\)$`)
 	deviceNameRegexp := regexp.MustCompile(`^([a-zA-Z0-9\/\.-]+) is.*$`)
-	adminStatusRegexp := regexp.MustCompile(`^.+ is (administratively)?\s*(up|down).*, line protocol is.*$`)
+	adminStatusRegexp := regexp.MustCompile(`^.+ is (administratively)?\s*(up|down).*, line protocol is\s+(up|down).*$`)
 	adminStatusNXOSRegexp := regexp.MustCompile(`^\S+ is (up|down)(?:\s|,)?(\(Administratively down\))?.*$`)
 	descRegexp := regexp.MustCompile(`^\s+Description: (.*)$`)
 	dropsRegexp := regexp.MustCompile(`^\s+Input queue: \d+\/\d+\/(\d+)\/\d+ .+ Total output drops: (\d+)$`)
@@ -59,7 +59,11 @@ func (c *interfaceCollector) Parse(ostype string, output string) ([]Interface, e
 			} else {
 				current.AdminStatus = "down"
 			}
-			current.OperStatus = matches[2]
+			if matches[2] == "up" && matches[3] == "up" {
+				current.OperStatus = "up"
+			} else {
+				current.OperStatus = "down"
+			}
 		} else if matches := adminStatusNXOSRegexp.FindStringSubmatch(line); matches != nil {
 			if matches[2] == "" {
 				current.AdminStatus = "up"


### PR DESCRIPTION
Currently if an interfaces is:

```
Vlan8 is up, line protocol is down , Autostate Enabled
```

cisco_interface_up reports 1 which is not what you want in most cases. Changed so line protocol state is also considered.
