### PR TITLE
add metrics for NAT64 translations

### DIFF
--- a/collectors.go
+++ b/collectors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lwlcom/cisco_exporter/facts"
 	"github.com/lwlcom/cisco_exporter/interfaces"
 	"github.com/lwlcom/cisco_exporter/inventory"
+	"github.com/lwlcom/cisco_exporter/nat64"
 	"github.com/lwlcom/cisco_exporter/neighbors"
 	"github.com/lwlcom/cisco_exporter/optics"
 )
@@ -45,6 +46,7 @@ func (c *collectors) initCollectorsForDevice(device *connector.Device, descRe *r
 	c.addCollectorIfEnabledForDevice(device, "interfaces", f.Interfaces, func() collector.RPCCollector {
 		return interfaces.NewCollector(descRe)
 	})
+	c.addCollectorIfEnabledForDevice(device, "nat64", f.Nat64, nat64.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "neighbors", f.Neighbors, neighbors.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "optics", f.Optics, optics.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "inventory", f.Inventory, inventory.NewCollector)

--- a/config.yml.example
+++ b/config.yml.example
@@ -25,3 +25,4 @@ features:
   facts: true
   interfaces: true
   optics: true
+  nat64: false

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type FeatureConfig struct {
 	Environment *bool `yaml:"environment,omitempty"`
 	Facts       *bool `yaml:"facts,omitempty"`
 	Interfaces  *bool `yaml:"interfaces,omitempty"`
+	Nat64       *bool `yaml:"nat64,omitempty"`
 	Neighbors   *bool `yaml:"neighbors,omitempty"`
 	Optics      *bool `yaml:"optics,omitempty"`
 	Inventory   *bool `yaml:"inventory,omitempty"`
@@ -127,6 +128,9 @@ func Load(reader io.Reader) (*Config, error) {
 		if d.Features.Interfaces == nil {
 			d.Features.Interfaces = c.Features.Interfaces
 		}
+		if d.Features.Nat64 == nil {
+			d.Features.Nat64 = c.Features.Nat64
+		}
 		if d.Features.Neighbors == nil {
 			d.Features.Neighbors = c.Features.Neighbors
 		}
@@ -157,6 +161,8 @@ func (c *Config) setDefaultValues() {
 	f.Facts = &facts
 	interfaces := true
 	f.Interfaces = &interfaces
+	nat64 := false
+	f.Nat64 = &nat64
 	neighbors := false
 	f.Neighbors = &neighbors
 	optics := true

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	bgpEnabled         = flag.Bool("bgp.enabled", true, "Scrape bgp metrics")
 	environmentEnabled = flag.Bool("environment.enabled", true, "Scrape environment metrics")
 	factsEnabled       = flag.Bool("facts.enabled", true, "Scrape system metrics")
+	nat64Enabled       = flag.Bool("nat64.enabled", false, "Scrape NAT64 translation stats")
 	neighborsEnabled   = flag.Bool("neighbors.enabled", false, "Scrape neighbor counts (ARP & IPv6 ND table size)")
 	interfacesEnabled  = flag.Bool("interfaces.enabled", true, "Scrape interface metrics")
 	opticsEnabled      = flag.Bool("optics.enabled", true, "Scrape optic metrics")
@@ -118,6 +119,7 @@ func loadConfigFromFlags() *config.Config {
 	f.Environment = environmentEnabled
 	f.Facts = factsEnabled
 	f.Interfaces = interfacesEnabled
+	f.Nat64 = nat64Enabled
 	f.Neighbors = neighborsEnabled
 	f.Optics = opticsEnabled
 	f.Inventory = inventoryEnabled

--- a/nat64/nat64.go
+++ b/nat64/nat64.go
@@ -1,0 +1,10 @@
+package nat64
+
+type Nat64Stats struct {
+	translationsActive    float64 `default:"0"`
+	translationsExpired   float64 `default:"0"`
+	sessionsFound         float64 `default:"0"`
+	sessionsCreated       float64 `default:"0"`
+	packetsTranslated4to6 float64 `default:"0"`
+	packetsTranslated6to4 float64 `default:"0"`
+}

--- a/nat64/nat64_collector.go
+++ b/nat64/nat64_collector.go
@@ -1,0 +1,78 @@
+package nat64
+
+import (
+	"log"
+
+	"github.com/lwlcom/cisco_exporter/rpc"
+
+	"github.com/lwlcom/cisco_exporter/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "cisco_nat64_"
+
+var (
+	translationsActiveDesc    *prometheus.Desc
+	translationsExpiredDesc   *prometheus.Desc
+	sessionsFoundDesc         *prometheus.Desc
+	sessionsCreatedDesc       *prometheus.Desc
+	packetsTranslated4to6Desc *prometheus.Desc
+	packetsTranslated6to4Desc *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target"}
+	translationsActiveDesc = prometheus.NewDesc(prefix+"translations_active", "Currently active NAT64 translations", l, nil)
+	translationsExpiredDesc = prometheus.NewDesc(prefix+"translations_expired", "Total number of NAT64 translations removed from session table", l, nil)
+	sessionsFoundDesc = prometheus.NewDesc(prefix+"sessions_found", "Count of packets that matched existing session in NAT64 session table", l, nil)
+	sessionsCreatedDesc = prometheus.NewDesc(prefix+"sessions_created", "Count of new sessions created in NAT64 session table", l, nil)
+	packetsTranslated4to6Desc = prometheus.NewDesc(prefix+"packets_translated_4to6", "Count of packets translated from IPv4 to IPv6", l, nil)
+	packetsTranslated6to4Desc = prometheus.NewDesc(prefix+"packets_translated_6to4", "Count of packets translated from IPv6 to IPv4", l, nil)
+}
+
+type nat64Collector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &nat64Collector{}
+}
+
+// Name returns the name of the collector
+func (*nat64Collector) Name() string {
+	return "NAT64"
+}
+
+// Describe describes the metrics
+func (*nat64Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- translationsActiveDesc
+	ch <- translationsExpiredDesc
+	ch <- sessionsFoundDesc
+	ch <- sessionsCreatedDesc
+	ch <- packetsTranslated4to6Desc
+	ch <- packetsTranslated6to4Desc
+}
+
+// Collect collects metrics from Cisco
+func (c *nat64Collector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	out, err := client.RunCommand("show nat64 statistics global")
+	if err != nil {
+		return err
+	}
+	stats, err := c.ParseNat64(client.OSType, out)
+	if err != nil {
+		if client.Debug {
+			log.Printf("ParseNat64 for %s: %s\n", labelValues[0], err)
+		}
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(translationsActiveDesc, prometheus.GaugeValue, float64(stats.translationsActive), labelValues...)
+	ch <- prometheus.MustNewConstMetric(translationsExpiredDesc, prometheus.CounterValue, float64(stats.translationsExpired), labelValues...)
+	ch <- prometheus.MustNewConstMetric(sessionsFoundDesc, prometheus.CounterValue, float64(stats.sessionsFound), labelValues...)
+	ch <- prometheus.MustNewConstMetric(sessionsCreatedDesc, prometheus.CounterValue, float64(stats.sessionsCreated), labelValues...)
+	ch <- prometheus.MustNewConstMetric(packetsTranslated4to6Desc, prometheus.CounterValue, float64(stats.packetsTranslated4to6), labelValues...)
+	ch <- prometheus.MustNewConstMetric(packetsTranslated6to4Desc, prometheus.CounterValue, float64(stats.packetsTranslated6to4), labelValues...)
+
+	return nil
+}

--- a/nat64/parser.go
+++ b/nat64/parser.go
@@ -1,0 +1,31 @@
+package nat64
+
+import (
+	"errors"
+
+	"github.com/lwlcom/cisco_exporter/rpc"
+	"github.com/lwlcom/cisco_exporter/util"
+)
+
+// ParseNat64 parses cli output and returns values
+func (c *nat64Collector) ParseNat64(ostype string, output string) (Nat64Stats, error) {
+	if ostype != rpc.IOSXE {
+		return Nat64Stats{}, errors.New("'show nat64 statistics global' is not implemented for " + ostype)
+	}
+
+	results, err := util.ParseTextfsm(templ_nat64, output)
+	if err != nil {
+		return Nat64Stats{}, errors.New("Error parsing via templ_nat64: " + err.Error())
+	}
+
+	result := results[0]
+	stats := Nat64Stats{
+		translationsActive:    util.Str2float64(result["nat64_total_active_translations"].(string)),
+		translationsExpired:   util.Str2float64(result["nat64_expired_translations"].(string)),
+		sessionsFound:         util.Str2float64(result["nat64_sessions_found"].(string)),
+		sessionsCreated:       util.Str2float64(result["nat64_sessions_created"].(string)),
+		packetsTranslated4to6: util.Str2float64(result["nat64_ipv4_ipv6_translated_packets"].(string)),
+		packetsTranslated6to4: util.Str2float64(result["nat64_ipv6_ipv4_translated_packets"].(string)),
+	}
+	return stats, nil
+}

--- a/nat64/templates.go
+++ b/nat64/templates.go
@@ -1,0 +1,44 @@
+package nat64
+
+/*
+ * # ASR1000
+ * # show nat64 statistics global
+ * NAT64 Statistics
+ *
+ * Total active translations: 238814 (0 static, 238814 dynamic; 238814 extended)
+ * Sessions found: 761031179766
+ * Sessions created: 4144454051
+ * Expired translations: 4149896490
+ * Global Stats:
+ *
+ * 	Packets translated (IPv4 -> IPv6)
+ * 	   Stateless: 0
+ * 	   Stateful: 536010887327
+ * 	   MAP-T: 0
+ * 	Packets translated (IPv6 -> IPv4)
+ * 	   Stateless: 0
+ * 	   Stateful: 229167550920
+ * 	   MAP-T: 0
+ */
+var templ_nat64 = `# show nat64 statistics global
+Value nat64_total_active_translations (\d+)
+Value nat64_sessions_found (\d+)
+Value nat64_sessions_created (\d+)
+Value nat64_expired_translations (\d+)
+Value nat64_ipv4_ipv6_translated_packets (\d+)
+Value nat64_ipv6_ipv4_translated_packets (\d+)
+
+Start
+  ^Total\s+active\s+translations:\s+${nat64_total_active_translations}
+  ^Sessions\s+found:\s+${nat64_sessions_found}
+  ^Sessions\s+created:\s+${nat64_sessions_created}
+  ^Expired\s+translations:\s+${nat64_expired_translations}
+  ^\s+Packets translated \(IPv4 \-\> IPv6\) -> IP46
+  ^\s+Packets translated \(IPv6 \-\> IPv4\) -> IP64
+
+IP46
+  ^\s+Stateful:\s+${nat64_ipv4_ipv6_translated_packets} -> Start
+
+IP64
+  ^\s+Stateful:\s+${nat64_ipv6_ipv4_translated_packets} -> Record
+`


### PR DESCRIPTION
Parses `show nat64 statistics global` and returns translation & session stats. Example metrics:

```openmetrics
# HELP cisco_nat64_packets_translated_4to6 Count of packets translated from IPv4 to IPv6
# TYPE cisco_nat64_packets_translated_4to6 counter
cisco_nat64_packets_translated_4to6{target="router"} 5.36184195349e+11
# HELP cisco_nat64_packets_translated_6to4 Count of packets translated from IPv6 to IPv4
# TYPE cisco_nat64_packets_translated_6to4 counter
cisco_nat64_packets_translated_6to4{target="router"} 2.29241330353e+11
# HELP cisco_nat64_sessions_created Count of new sessions created in NAT64 session table
# TYPE cisco_nat64_sessions_created counter
cisco_nat64_sessions_created{target="router"} 4.145862815e+09
# HELP cisco_nat64_sessions_found Count of packets that matched existing session in NAT64 session table
# TYPE cisco_nat64_sessions_found counter
cisco_nat64_sessions_found{target="router"} 7.61276856742e+11
# HELP cisco_nat64_translations_active Currently active NAT64 translations
# TYPE cisco_nat64_translations_active gauge
cisco_nat64_translations_active{target="router"} 37708
# HELP cisco_nat64_translations_expired Total number of NAT64 translations removed from session table
# TYPE cisco_nat64_translations_expired counter
cisco_nat64_translations_expired{target="router"} 4.151509052e+09
```

Currently supports only stateful NAT64.

Tested only on Cisco ASR1000 Version 16.6.4
